### PR TITLE
Rename crc module to crc8

### DIFF
--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -33,13 +33,13 @@ pub fn validate(buf: &[u8]) -> Result<(), ()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::crc;
+    use crate::crc8;
 
     /// Test the crc function against the test value provided in the SHTC3 datasheet (section
     /// 5.10).
     #[test]
     fn crc8_test_value() {
-        assert_eq!(crc::calculate(&[0x00]), 0xac);
-        assert_eq!(crc::calculate(&[0xbe, 0xef]), 0x92);
+        assert_eq!(crc8::calculate(&[0x00]), 0xac);
+        assert_eq!(crc8::calculate(&[0xbe, 0xef]), 0x92);
     }
 }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,4 +1,4 @@
-use crate::crc;
+use crate::crc8;
 use embedded_hal::blocking::i2c;
 
 /// All possible errors in this crate
@@ -35,5 +35,5 @@ pub fn read_words_with_crc<I2c: i2c::Read + i2c::Write>(
         "Buffer must hold a multiple of 3 bytes"
     );
     i2c.try_read(addr, data).map_err(Error::I2cRead)?;
-    crc::validate(data).map_err(|_| Error::Crc)
+    crc8::validate(data).map_err(|_| Error::Crc)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 
-pub mod crc;
+pub mod crc8;
 pub mod i2c;
 
 #[cfg(test)]


### PR DESCRIPTION
The module only contains a CRC-8 implementation and not general CRC
implementations.