### PR TITLE
Remove -rs suffix from package name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "sensirion-i2c-rs"
+name = "sensirion-i2c"
 version = "0.1.0"
 authors = ["Raphael Nestler <raphael.nestler@sensirion.com>"]
 description = "Common functionality for I2C based sensors from Sensirion"


### PR DESCRIPTION
It is clear that it is a Rust package if it is on crates.io without the
-rs suffix ;)