### PR TITLE
Remove meaningless test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,11 +33,3 @@
 
 pub mod crc8;
 pub mod i2c;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
That one gets added by cargo when creating a new library project.