### PR TITLE
Assert in crc8::validate that buffer size is a multiple of 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This project follows [semantic versioning](https://semver.org/).
 
+## [Unreleased]
+
+## Changed
+
+ * Panic in `crc8::validate` if buffer size is not a multiple of 3
+   ([#13](https://github.com/Sensirion/sensirion-i2c-rs/pull/13)
+
 ## [0.1.0] (2020-08-21)
 
  * Initial version which implements the CRC-8 algorithm commonly used by

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -23,12 +23,14 @@ pub fn calculate(data: &[u8]) -> u8 {
 /// is the checksum byte of the previous two bytes
 /// If the checksum is wrong, return `Err`.
 ///
-/// Note: This method will consider every third byte a checksum byte. If the buffer size is not a
-/// multiple of 3, then not all data will be validated.
+/// # Panics
+///
+/// This method will consider every third byte a checksum byte. If the buffer size is not a
+/// multiple of 3, then it will panic.
 pub fn validate(buf: &[u8]) -> Result<(), ()> {
-    debug_assert!(buf.len() % 3 == 0, "Buffer must be a multiple of 3");
+    assert!(buf.len() % 3 == 0, "Buffer must be a multiple of 3");
     for chunk in buf.chunks(3) {
-        if chunk.len() == 3 && calculate(&[chunk[0], chunk[1]]) != chunk[2] {
+        if calculate(&[chunk[0], chunk[1]]) != chunk[2] {
             return Err(());
         }
     }


### PR DESCRIPTION
Previously crc8::validate would only panic in debug builds, but not in
release builds when passing in buffers with a size which isn't a
multiple of 3. In release builds the remaining bytes just wouldn't get
validated.

Fixes #10