### PR TITLE
Assert in i2c::read_words_with_crc that buffer size is a multiple of 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
-## Changed
+### Changed
 
- * Panic in `crc8::validate` if buffer size is not a multiple of 3
-   ([#13](https://github.com/Sensirion/sensirion-i2c-rs/pull/13)
+ * Panic in `crc8::validate` and `i2c::read_words_with_crc` if buffer size is
+   not a multiple of 3
+   ([#13](https://github.com/Sensirion/sensirion-i2c-rs/pull/13),
+   [#15](https://github.com/Sensirion/sensirion-i2c-rs/pull/15))
 
 ## [0.1.0] (2020-08-21)
 

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -24,15 +24,16 @@ pub fn write_command<I2cWrite: i2c::Write>(
 ///
 /// If the checksum is wrong, return `Error::Crc`.
 ///
-/// Note: This method will consider every third byte a checksum byte. If
-/// the buffer size is not a multiple of 3, then not all data will be
-/// validated.
+/// # Panics
+///
+/// This method will consider every third byte a checksum byte. If the buffer size is not a
+/// multiple of 3, then it will panic.
 pub fn read_words_with_crc<I2c: i2c::Read + i2c::Write>(
     i2c: &mut I2c,
     addr: u8,
     data: &mut [u8],
 ) -> Result<(), Error<I2c, I2c>> {
-    debug_assert!(
+    assert!(
         data.len() % 3 == 0,
         "Buffer must hold a multiple of 3 bytes"
     );


### PR DESCRIPTION
Previously it would only panic in debug builds to match the behaviour of
crc8::validate. But since we changed that in #13 it makes sense to adapt
here as well.