### PR TITLE
Remove panicking behavior

### DIFF
--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -1,5 +1,11 @@
 //! Helper functions for CRC8 checksum validation
 
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Error {
+    WrongBufferSize,
+    WrongCrc,
+}
+
 /// Calculate the CRC8 checksum.
 pub fn calculate(data: &[u8]) -> u8 {
     const CRC8_POLYNOMIAL: u8 = 0x31;
@@ -17,12 +23,6 @@ pub fn calculate(data: &[u8]) -> u8 {
     crc
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum Error {
-    WrongCrc,
-    WrongBufferSize,
-}
-
 /// Iterate over the provided buffer and validate the CRC8 checksums.
 ///
 /// The buffer must be in the form of `[d0, d1, crc01, d2, d3, crc23, ...]` where every third byte
@@ -37,7 +37,7 @@ pub fn validate(buf: &[u8]) -> Result<(), Error> {
     }
     for chunk in buf.chunks(3) {
         if calculate(&[chunk[0], chunk[1]]) != chunk[2] {
-            return Err(Error::WrongCrc);
+            return Err(Error::WrongCrc)
         }
     }
     Ok(())

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -17,21 +17,27 @@ pub fn calculate(data: &[u8]) -> u8 {
     crc
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+    WrongCrc,
+    WrongBufferSize,
+}
+
 /// Iterate over the provided buffer and validate the CRC8 checksums.
 ///
 /// The buffer must be in the form of `[d0, d1, crc01, d2, d3, crc23, ...]` where every third byte
 /// is the checksum byte of the previous two bytes
-/// If the checksum is wrong, return `Err`.
-///
-/// # Panics
+/// If any checksum is wrong, return `Error::WrongCrc`.
 ///
 /// This method will consider every third byte a checksum byte. If the buffer size is not a
-/// multiple of 3, then it will panic.
-pub fn validate(buf: &[u8]) -> Result<(), ()> {
-    assert!(buf.len() % 3 == 0, "Buffer must be a multiple of 3");
+/// multiple of 3, then it will return `Error::WrongBufferSize`
+pub fn validate(buf: &[u8]) -> Result<(), Error> {
+    if buf.len() % 3 != 0 {
+        return Err(Error::WrongBufferSize);
+    }
     for chunk in buf.chunks(3) {
         if calculate(&[chunk[0], chunk[1]]) != chunk[2] {
-            return Err(());
+            return Err(Error::WrongCrc);
         }
     }
     Ok(())
@@ -40,6 +46,7 @@ pub fn validate(buf: &[u8]) -> Result<(), ()> {
 #[cfg(test)]
 mod tests {
     use crate::crc8;
+    use crate::crc8::Error;
 
     /// Test the crc function against the test value provided in the SHTC3 datasheet (section
     /// 5.10).
@@ -50,22 +57,21 @@ mod tests {
     }
 
     #[test]
-    fn crc8_validate_empty() {
-        crc8::validate(&[]).unwrap();
+    fn crc8_validate_empty_ok() {
+        assert!(crc8::validate(&[]).is_ok());
     }
 
     #[test]
-    #[should_panic]
     fn crc8_validate_not_enough_data() {
-        crc8::validate(&[0xbe]).unwrap();
+        assert_eq!(Err(Error::WrongBufferSize), crc8::validate(&[0xbe]));
     }
 
     #[test]
     fn crc8_validate() {
         // Valid CRC
-        crc8::validate(&[0xbe, 0xef, 0x92]).unwrap();
+        assert!(crc8::validate(&[0xbe, 0xef, 0x92]).is_ok());
 
         // Invalid CRC
-        assert_eq!(crc8::validate(&[0xbe, 0xef, 0x91]), Err(()));
+        assert_eq!(crc8::validate(&[0xbe, 0xef, 0x91]), Err(Error::WrongCrc));
     }
 }

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -37,7 +37,7 @@ pub fn validate(buf: &[u8]) -> Result<(), Error> {
     }
     for chunk in buf.chunks(3) {
         if calculate(&[chunk[0], chunk[1]]) != chunk[2] {
-            return Err(Error::WrongCrc)
+            return Err(Error::WrongCrc);
         }
     }
     Ok(())

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,7 +1,7 @@
 //! Helper functions for the u16 word based I²C communication.
 
 use crate::crc8;
-use crate::Error;
+pub use crate::Error;
 use embedded_hal::blocking::i2c;
 
 /// Write an u16 command to the I²C bus.

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -2,14 +2,7 @@
 
 use crate::crc8;
 use embedded_hal::blocking::i2c;
-
-/// All possible errors in this crate
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub enum Error<I2cWrite: i2c::Write, I2cRead: i2c::Read> {
-    I2cWrite(I2cWrite::Error),
-    I2cRead(I2cRead::Error),
-    Crc,
-}
+use crate::Error;
 
 /// Write an u16 command to the I²C bus.
 pub fn write_command<I2cWrite: i2c::Write>(
@@ -24,21 +17,18 @@ pub fn write_command<I2cWrite: i2c::Write>(
 ///
 /// If the checksum is wrong, return `Error::Crc`.
 ///
-/// # Panics
-///
 /// This method will consider every third byte a checksum byte. If the buffer size is not a
-/// multiple of 3, then it will panic.
+/// multiple of 3, then it will return `Error::WrongBufferSize`
 pub fn read_words_with_crc<I2c: i2c::Read + i2c::Write>(
     i2c: &mut I2c,
     addr: u8,
     data: &mut [u8],
 ) -> Result<(), Error<I2c, I2c>> {
-    assert!(
-        data.len() % 3 == 0,
-        "Buffer must hold a multiple of 3 bytes"
-    );
+    if data.len() % 3 != 0 {
+        return Err(Error::WrongBufferSize)
+    }
     i2c.read(addr, data).map_err(Error::I2cRead)?;
-    crc8::validate(data).map_err(|_| Error::Crc)
+    Ok(crc8::validate(data)?)
 }
 
 #[cfg(test)]
@@ -62,7 +52,7 @@ mod tests {
         let expectations = [Transaction::read(0x58, vec![0xBE, 0xEF, 0x00])];
         let mut mock = I2cMock::new(&expectations);
         match i2c::read_words_with_crc(&mut mock, 0x58, &mut buf) {
-            Err(i2c::Error::Crc) => {}
+            Err(i2c::Error::WrongCrc) => {}
             Err(_) => panic!("Invalid error: Must be Crc"),
             Ok(_) => panic!("CRC check did not fail"),
         }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,8 +1,8 @@
 //! Helper functions for the u16 word based I²C communication.
 
 use crate::crc8;
-use embedded_hal::blocking::i2c;
 use crate::Error;
+use embedded_hal::blocking::i2c;
 
 /// Write an u16 command to the I²C bus.
 pub fn write_command<I2cWrite: i2c::Write>(
@@ -25,7 +25,7 @@ pub fn read_words_with_crc<I2c: i2c::Read + i2c::Write>(
     data: &mut [u8],
 ) -> Result<(), Error<I2c, I2c>> {
     if data.len() % 3 != 0 {
-        return Err(Error::WrongBufferSize)
+        return Err(Error::WrongBufferSize);
     }
     i2c.read(addr, data).map_err(Error::I2cRead)?;
     Ok(crc8::validate(data)?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,8 +31,8 @@
 #![deny(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 
-use embedded_hal::blocking::i2c::Write;
 use embedded_hal::blocking::i2c::Read;
+use embedded_hal::blocking::i2c::Write;
 
 /// All possible errors in this crate
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -47,7 +47,7 @@ impl<I2cWrite: Write, I2cRead: Read> From<crc8::Error> for Error<I2cWrite, I2cRe
     fn from(err: crc8::Error) -> Self {
         match err {
             crc8::Error::WrongBufferSize => Error::WrongBufferSize,
-            crc8::Error::WrongCrc => Error::WrongCrc
+            crc8::Error::WrongCrc => Error::WrongCrc,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,5 +31,26 @@
 #![deny(unsafe_code)]
 #![cfg_attr(not(test), no_std)]
 
+use embedded_hal::blocking::i2c::Write;
+use embedded_hal::blocking::i2c::Read;
+
+/// All possible errors in this crate
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub enum Error<I2cWrite: Write, I2cRead: Read> {
+    I2cWrite(I2cWrite::Error),
+    I2cRead(I2cRead::Error),
+    WrongBufferSize,
+    WrongCrc,
+}
+
+impl<I2cWrite: Write, I2cRead: Read> From<crc8::Error> for Error<I2cWrite, I2cRead> {
+    fn from(err: crc8::Error) -> Self {
+        match err {
+            crc8::Error::WrongBufferSize => Error::WrongBufferSize,
+            crc8::Error::WrongCrc => Error::WrongCrc
+        }
+    }
+}
+
 pub mod crc8;
 pub mod i2c;


### PR DESCRIPTION
Hi,

thanks for taking the time to make a Rust library for your I2C sensors!

I think this no_std library should not panic when a wrong buffer size is passed, or if a crc is wrong. Instead, the methods already return Result, so I extended the Error type. Tests are adapted too.

I split the Error type in crc8::Error and crate::Error (the crc8 module has it's own Error type) because I didn't want crc8 to require embedded_hal::i2c etc. Please let me know if you know a better way.