### PR TITLE
crc8: Use explicit error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project follows [semantic versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+ * Add a separate error type for the crc8 module to allow for
+   `From<crc8::Error>` implementations.
+   ([#18](https://github.com/Sensirion/sensirion-i2c-rs/pull/18/))
+
 ## [0.1.1] (2020-09-02)
 
 ### Changed

--- a/src/crc8.rs
+++ b/src/crc8.rs
@@ -1,5 +1,12 @@
 //! Helper functions for CRC8 checksum validation
 
+/// Errors which can happen in the crc8 module
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Error {
+    /// CRC validation failed
+    CrcError,
+}
+
 /// Calculate the CRC8 checksum.
 pub fn calculate(data: &[u8]) -> u8 {
     const CRC8_POLYNOMIAL: u8 = 0x31;
@@ -27,11 +34,11 @@ pub fn calculate(data: &[u8]) -> u8 {
 ///
 /// This method will consider every third byte a checksum byte. If the buffer size is not a
 /// multiple of 3, then it will panic.
-pub fn validate(buf: &[u8]) -> Result<(), ()> {
+pub fn validate(buf: &[u8]) -> Result<(), Error> {
     assert!(buf.len() % 3 == 0, "Buffer must be a multiple of 3");
     for chunk in buf.chunks(3) {
         if calculate(&[chunk[0], chunk[1]]) != chunk[2] {
-            return Err(());
+            return Err(Error::CrcError);
         }
     }
     Ok(())
@@ -66,6 +73,9 @@ mod tests {
         crc8::validate(&[0xbe, 0xef, 0x92]).unwrap();
 
         // Invalid CRC
-        assert_eq!(crc8::validate(&[0xbe, 0xef, 0x91]), Err(()));
+        assert_eq!(
+            crc8::validate(&[0xbe, 0xef, 0x91]),
+            Err(crc8::Error::CrcError)
+        );
     }
 }


### PR DESCRIPTION
Even if just one error can happen, it may be beneficial to be able to
have a separate error type to allow for `From<Error>` implementations.