### PR TITLE
Update rust version in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.32
+      - image: rust:1.63
     steps:
       - checkout
       - run: rustup component add rustfmt


### PR DESCRIPTION
Update rustc to 1.63 to support 2021 edition and embedded-hal 1.0.0.