### PR TITLE
Reduce explicit type assumptions of function signatures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ embedded-hal = "1.0"
 embedded-hal-async = { version = "1.0", optional = true }
 
 [dev-dependencies]
-embedded-hal-mock = { version = "0.10", features = ["eh1"] }
+embedded-hal-mock = { version = "0.11.1", features = ["eh1"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -21,18 +21,30 @@ impl<I: i2c::ErrorType> From<crc8::Error> for Error<I> {
 
 /// Write an u16 command to the I²C bus.
 #[deprecated(note = "Please use `write_command_u16` instead.")]
-pub fn write_command<I: i2c::I2c>(i2c: &mut I, addr: u8, command: u16) -> Result<(), I::Error> {
+pub fn write_command<A: i2c::AddressMode, I: i2c::I2c<A>>(
+    i2c: &mut I,
+    addr: A,
+    command: impl Into<u16>,
+) -> Result<(), I::Error> {
     write_command_u16(i2c, addr, command)
 }
 
 /// Write an u8 command to the I²C bus.
-pub fn write_command_u8<I: i2c::I2c>(i2c: &mut I, addr: u8, command: u8) -> Result<(), I::Error> {
-    i2c.write(addr, &command.to_be_bytes())
+pub fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A>>(
+    i2c: &mut I,
+    addr: A,
+    command: impl Into<u8>,
+) -> Result<(), I::Error> {
+    i2c.write(addr, &command.into().to_be_bytes())
 }
 
 /// Write an u16 command to the I²C bus.
-pub fn write_command_u16<I: i2c::I2c>(i2c: &mut I, addr: u8, command: u16) -> Result<(), I::Error> {
-    i2c.write(addr, &command.to_be_bytes())
+pub fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A>>(
+    i2c: &mut I,
+    addr: A,
+    command: impl Into<u16>,
+) -> Result<(), I::Error> {
+    i2c.write(addr, &command.into().to_be_bytes())
 }
 
 /// Read data into the provided buffer and validate the CRC8 checksum.
@@ -43,9 +55,9 @@ pub fn write_command_u16<I: i2c::I2c>(i2c: &mut I, addr: u8, command: u16) -> Re
 ///
 /// This method will consider every third byte a checksum byte. If the buffer size is not a
 /// multiple of 3, then it will panic.
-pub fn read_words_with_crc<I: i2c::I2c>(
+pub fn read_words_with_crc<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
-    addr: u8,
+    addr: A,
     data: &mut [u8],
 ) -> Result<(), Error<I>> {
     assert!(

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -44,7 +44,7 @@ pub fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A> + Debug>(
             .map_err(|_| Error::<I>::InvalidCommand)?
             .to_be_bytes(),
     )
-    .map_err(|e| Error::I2cWrite(e))
+    .map_err(Error::I2cWrite)
 }
 
 /// Write an u16 command to the I²C bus.
@@ -60,7 +60,7 @@ pub fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A> + Debug>(
             .map_err(|_| Error::<I>::InvalidCommand)?
             .to_be_bytes(),
     )
-    .map_err(|e| Error::I2cWrite(e))
+    .map_err(Error::I2cWrite)
 }
 
 /// Read data into the provided buffer and validate the CRC8 checksum.

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -2,6 +2,7 @@
 
 use crate::crc8;
 use core::{convert::TryInto, fmt::Debug};
+
 use embedded_hal::i2c;
 
 /// All possible errors in this crate

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,7 @@
 //! Helper functions for I²C communication.
 
 use crate::crc8;
+use core::{convert::TryInto, fmt::Debug};
 use embedded_hal::i2c;
 
 /// All possible errors in this crate
@@ -8,6 +9,7 @@ use embedded_hal::i2c;
 pub enum Error<I: i2c::ErrorType> {
     I2cWrite(I::Error),
     I2cRead(I::Error),
+    InvalidCommand,
     Crc,
 }
 
@@ -21,30 +23,44 @@ impl<I: i2c::ErrorType> From<crc8::Error> for Error<I> {
 
 /// Write an u16 command to the I²C bus.
 #[deprecated(note = "Please use `write_command_u16` instead.")]
-pub fn write_command<A: i2c::AddressMode, I: i2c::I2c<A>>(
+pub fn write_command<A: i2c::AddressMode, I: i2c::I2c<A> + Debug>(
     i2c: &mut I,
     addr: A,
-    command: impl Into<u16>,
-) -> Result<(), I::Error> {
+    command: impl TryInto<u16>,
+) -> Result<(), Error<I>> {
     write_command_u16(i2c, addr, command)
 }
 
 /// Write an u8 command to the I²C bus.
-pub fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A>>(
+pub fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A> + Debug>(
     i2c: &mut I,
     addr: A,
-    command: impl Into<u8>,
-) -> Result<(), I::Error> {
-    i2c.write(addr, &command.into().to_be_bytes())
+    command: impl TryInto<u8>,
+) -> Result<(), Error<I>> {
+    i2c.write(
+        addr,
+        &command
+            .try_into()
+            .map_err(|_| Error::<I>::InvalidCommand)?
+            .to_be_bytes(),
+    )
+    .map_err(|e| Error::I2cWrite(e))
 }
 
 /// Write an u16 command to the I²C bus.
-pub fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A>>(
+pub fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A> + Debug>(
     i2c: &mut I,
     addr: A,
-    command: impl Into<u16>,
-) -> Result<(), I::Error> {
-    i2c.write(addr, &command.into().to_be_bytes())
+    command: impl TryInto<u16>,
+) -> Result<(), Error<I>> {
+    i2c.write(
+        addr,
+        &command
+            .try_into()
+            .map_err(|_| Error::<I>::InvalidCommand)?
+            .to_be_bytes(),
+    )
+    .map_err(|e| Error::I2cWrite(e))
 }
 
 /// Read data into the provided buffer and validate the CRC8 checksum.
@@ -109,7 +125,7 @@ mod tests {
         let expectations = [Transaction::write(0x58, vec![0xab, 0xcd])];
         let mut mock = I2cMock::new(&expectations);
 
-        i2c::write_command(&mut mock, 0x58, 0xabcd as u16).unwrap();
+        i2c::write_command(&mut mock, 0x58, 0xabcd).unwrap();
 
         mock.done();
     }
@@ -129,7 +145,7 @@ mod tests {
         let expectations = [Transaction::write(0x58, vec![0xab, 0xcd])];
         let mut mock = I2cMock::new(&expectations);
 
-        i2c::write_command_u16(&mut mock, 0x58, 0xabcd as u16).unwrap();
+        i2c::write_command_u16(&mut mock, 0x58, 0xabcd).unwrap();
 
         mock.done();
     }

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -109,7 +109,7 @@ mod tests {
         let expectations = [Transaction::write(0x58, vec![0xab, 0xcd])];
         let mut mock = I2cMock::new(&expectations);
 
-        i2c::write_command(&mut mock, 0x58, 0xabcd).unwrap();
+        i2c::write_command(&mut mock, 0x58, 0xabcd as u16).unwrap();
 
         mock.done();
     }
@@ -129,7 +129,7 @@ mod tests {
         let expectations = [Transaction::write(0x58, vec![0xab, 0xcd])];
         let mut mock = I2cMock::new(&expectations);
 
-        i2c::write_command_u16(&mut mock, 0x58, 0xabcd).unwrap();
+        i2c::write_command_u16(&mut mock, 0x58, 0xabcd as u16).unwrap();
 
         mock.done();
     }

--- a/src/i2c_async.rs
+++ b/src/i2c_async.rs
@@ -12,21 +12,21 @@ use embedded_hal_async::i2c;
 pub use crate::i2c::Error;
 
 /// Write an u8 command to the I²C bus.
-pub async fn write_command_u8<I: i2c::I2c>(
+pub async fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
-    addr: u8,
-    command: u8,
+    addr: A,
+    command: impl Into<u8>,
 ) -> Result<(), I::Error> {
-    i2c.write(addr, &command.to_be_bytes()).await
+    i2c.write(addr, &command.into().to_be_bytes()).await
 }
 
 /// Write an u16 command to the I²C bus.
-pub async fn write_command_u16<I: i2c::I2c>(
+pub async fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
-    addr: u8,
-    command: u16,
+    addr: A,
+    command: impl Into<u16>,
 ) -> Result<(), I::Error> {
-    i2c.write(addr, &command.to_be_bytes()).await
+    i2c.write(addr, &command.into().to_be_bytes()).await
 }
 
 /// Read data into the provided buffer and validate the CRC8 checksum.
@@ -37,9 +37,9 @@ pub async fn write_command_u16<I: i2c::I2c>(
 ///
 /// This method will consider every third byte a checksum byte. If the buffer size is not a
 /// multiple of 3, then it will panic.
-pub async fn read_words_with_crc<I: i2c::I2c>(
+pub async fn read_words_with_crc<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
-    addr: u8,
+    addr: A,
     data: &mut [u8],
 ) -> Result<(), Error<I>> {
     assert!(

--- a/src/i2c_async.rs
+++ b/src/i2c_async.rs
@@ -7,7 +7,7 @@
 //! [`embedded-hal-async`]: https://crates.io/crates/embedded-hal-async
 
 use crate::crc8;
-use core::{convert::TryInto, fmt::Debug};
+use core::convert::TryInto;
 use embedded_hal_async::i2c;
 
 pub use crate::i2c::Error;

--- a/src/i2c_async.rs
+++ b/src/i2c_async.rs
@@ -7,6 +7,7 @@
 //! [`embedded-hal-async`]: https://crates.io/crates/embedded-hal-async
 
 use crate::crc8;
+use core::{convert::TryInto, fmt::Debug};
 use embedded_hal_async::i2c;
 
 pub use crate::i2c::Error;

--- a/src/i2c_async.rs
+++ b/src/i2c_async.rs
@@ -15,18 +15,34 @@ pub use crate::i2c::Error;
 pub async fn write_command_u8<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
     addr: A,
-    command: impl Into<u8>,
-) -> Result<(), I::Error> {
-    i2c.write(addr, &command.into().to_be_bytes()).await
+    command: impl TryInto<u8>,
+) -> Result<(), Error<I>> {
+    i2c.write(
+        addr,
+        &command
+            .try_into()
+            .map_err(|_| Error::InvalidCommand)?
+            .to_be_bytes(),
+    )
+    .await
+    .map_err(Error::I2cWrite)
 }
 
 /// Write an u16 command to the I²C bus.
 pub async fn write_command_u16<A: i2c::AddressMode, I: i2c::I2c<A>>(
     i2c: &mut I,
     addr: A,
-    command: impl Into<u16>,
-) -> Result<(), I::Error> {
-    i2c.write(addr, &command.into().to_be_bytes()).await
+    command: impl TryInto<u16>,
+) -> Result<(), Error<I>> {
+    i2c.write(
+        addr,
+        &command
+            .try_into()
+            .map_err(|_| Error::InvalidCommand)?
+            .to_be_bytes(),
+    )
+    .await
+    .map_err(Error::I2cWrite)
 }
 
 /// Read data into the provided buffer and validate the CRC8 checksum.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! let expectations = [I2cTransaction::write(0x12, vec![0x34, 0x56])];
 //! let mut i2c_mock = I2cMock::new(&expectations);
-//! i2c::write_command_u16(&mut i2c_mock, 0x12, 0x3456);
+//! i2c::write_command_u16(&mut i2c_mock, 0x12, 0x3456 as u16);
 //! i2c_mock.done();
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! let expectations = [I2cTransaction::write(0x12, vec![0x34, 0x56])];
 //! let mut i2c_mock = I2cMock::new(&expectations);
-//! i2c::write_command_u16(&mut i2c_mock, 0x12, 0x3456 as u16);
+//! i2c::write_command_u16(&mut i2c_mock, 0x12, 0x3456);
 //! i2c_mock.done();
 //! ```
 //!


### PR DESCRIPTION
The function signatures were requiring users to pass in explicit types instead of the slightly more idiomatic way of `impl Into<T>` that adds flexibility to the users of this library...

- `impl Into<T>` is better than directly requiring `T` because it allows the function to accept any type that can be converted into a `T` making the function more flexible, reusable, and extensible.
- It enables type inference, so you don't need to manually specify the type when calling the function.
- It avoids boilerplate code by automatically handling conversions between types that implement `Into<T>`.
- It supports a wider range of types and makes the code more generic and maintainable.